### PR TITLE
Update extract-i18n for extraction-style string management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea/
 spec/.examples.txt
 Gemfile.lock

--- a/lib/extract_i18n/adapters/ruby_adapter.rb
+++ b/lib/extract_i18n/adapters/ruby_adapter.rb
@@ -53,7 +53,8 @@ module ExtractI18n::Adapters
         else
           inner_source = i.children[0].loc.expression.source.gsub(/^#\{|}$/, '')
           interpolate_key = ExtractI18n.key(inner_source)
-          out_string += "%{#{interpolate_key}}"
+          # because we're using ICU, interpolation happens just with curly braces, no %
+          out_string += "{#{interpolate_key}}"
           interpolate_arguments[interpolate_key] = inner_source
         end
       end
@@ -77,7 +78,9 @@ module ExtractI18n::Adapters
 
     def ask_and_continue(i18n_key:, i18n_string:, interpolate_arguments: {}, node:)
       change = ExtractI18n::SourceChange.new(
-        i18n_key: "#{@file_key}.#{i18n_key}",
+        # we want the key to be the string itself so that we can extract it later
+        i18n_key: "#{i18n_string}",
+        i18n_string: "#{i18n_string}",
         i18n_string: i18n_string,
         interpolate_arguments: interpolate_arguments,
         source_line: node.location.expression.source_line,

--- a/lib/extract_i18n/file_processor.rb
+++ b/lib/extract_i18n/file_processor.rb
@@ -26,7 +26,8 @@ module ExtractI18n
         puts Diffy::Diff.new(original_content, result, context: 1).to_s(:color)
         if PROMPT.yes?("Save changes?")
           File.write(@file_path, result)
-          update_i18n_yml_file
+          # We are using a text extraction pipeline, so don't need this file
+          # update_i18n_yml_file
           puts PASTEL.green("Saved #{@file_path}")
         end
       end

--- a/lib/extract_i18n/source_change.rb
+++ b/lib/extract_i18n/source_change.rb
@@ -28,7 +28,8 @@ module ExtractI18n
       interpolate_arguments:,
       source_line:,
       remove:,
-      t_template: %{I18n.t("%s"%s)},
+      # we are using our own _t method by default
+      t_template: %{_t("%s"%s)},
       interpolation_type: :ruby
     )
       @i18n_string = i18n_string
@@ -56,7 +57,8 @@ module ExtractI18n
       unless @source_line.include?("\n")
         s += "\n"
       end
-      s += PASTEL.cyan("add i18n: ") + PASTEL.blue("#{@key}: #{@i18n_string}")
+      # We are using a text extraction pipeline, so we don't need this line
+      # s += PASTEL.cyan("add i18n: ") + PASTEL.yellow("#{@key}: #{@i18n_string}")
       s
     end
 
@@ -66,6 +68,12 @@ module ExtractI18n
                  else
                    key
                  end
+      # let's not have dangling commas for strings with no arguments
+      @t_template = if i18n_arguments_string.length > 0
+                      %{_t("%s"%s)}
+                    else
+                      %{_t("%s")}
+                    end
       sprintf(@t_template, i18n_key, i18n_arguments_string)
     end
 


### PR DESCRIPTION
- Because we're extracting strings, we need them to be marked correctly and use our translation helper methods
- We also don't need to create a file, so let's not
- Defaulting to double quotes to avoid writing code to detect inner quotes; we can let RuboCop fix it when we run the tool on our repo
- ignore rubymine files