### PR TITLE
Fix executables listing

### DIFF
--- a/extract_i18n.gemspec
+++ b/extract_i18n.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   << "extract-i18n"
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'nokogiri'


### PR DESCRIPTION
When we install this gem using Bundler's `path:` option in a `Gemfile`, and we're caching gems, the dynamic lookup of executables doesn't work b/c we're not in the repo's Git dir. Instead, just list the one executable we publish.