### PR TITLE
fix: in case the YML file does not exist

### DIFF
--- a/lib/extract_i18n/file_processor.rb
+++ b/lib/extract_i18n/file_processor.rb
@@ -89,6 +89,11 @@ module ExtractI18n
           end
         end
       end
+
+      # in case the file does not exist, we must make
+      # sure to create the intermediate folders
+      FileUtils.mkdir_p(File.dirname(@write_to))
+
       File.write(@write_to, base.to_yaml)
     end
 

--- a/spec/file_processor_spec.rb
+++ b/spec/file_processor_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ExtractI18n::FileProcessor do
     Dir.chdir(pwd)
   end
 
-  let(:yml) { 'locales.en.yml' }
+  let(:yml) { 'foo/bar/locales.en.yml' }
   before(:each) do
     allow_any_instance_of(TTY::Prompt).to receive(:yes?).and_return(true)
     allow_any_instance_of(TTY::Prompt).to receive(:no?).and_return(false)


### PR DESCRIPTION
When the folder structure where we want to store the YML with the texts does not exist, `File.write` throws an error, because it is not able to create the intermediate folders between the root and the YML file.