### PR TITLE
Override NodeMatch#to_s instead of calling inspect + format improvements

### DIFF
--- a/lib/extract_i18n/html_extractor/match/node_match.rb
+++ b/lib/extract_i18n/html_extractor/match/node_match.rb
@@ -17,6 +17,10 @@ module ExtractI18n
           raise NotImplementedError
         end
 
+        def to_s
+          text
+        end
+
         attr_writer :key
 
         def key

--- a/lib/extract_i18n/source_change.rb
+++ b/lib/extract_i18n/source_change.rb
@@ -34,7 +34,7 @@ module ExtractI18n
       @i18n_string = i18n_string
       @key = i18n_key
       @interpolate_arguments = interpolate_arguments
-      @source_line = source_line
+      @source_line = source_line.nil? ? "" : source_line
       @remove = remove
       @t_template = t_template
       @interpolation_type = interpolation_type
@@ -42,9 +42,9 @@ module ExtractI18n
 
     def format
       s = ""
-      s += PASTEL.cyan("replace:  ") + PASTEL.blue(@source_line).
+      s += PASTEL.cyan("\nreplace:  ") + PASTEL.blue(@source_line).
            gsub(@remove, PASTEL.red(@remove))
-      unless @source_line.include?("\n")
+      unless @source_line.end_with?("\n")
         s += "\n"
       end
       if @source_line[@remove]
@@ -53,7 +53,7 @@ module ExtractI18n
       else
         s += PASTEL.cyan("with:     ") + PASTEL.green(i18n_t)
       end
-      unless @source_line.include?("\n")
+      unless @source_line.end_with?("\n")
         s += "\n"
       end
       s += PASTEL.cyan("add i18n: ") + PASTEL.blue("#{@key}: #{@i18n_string}")


### PR DESCRIPTION
When running `extract-i18n` on `erb` files, plain text matches get printed as:
``` bash
replace:  #<ExtractI18n::HTMLExtractor::Match::PlainTextMatch:0x00007fd7e41910e0>`
```


Solution: Override `to_s` so it prints the actual text to be replaced.
