### PR TITLE
fix wrong preview changes

### DIFF
--- a/lib/extract_i18n/file_processor.rb
+++ b/lib/extract_i18n/file_processor.rb
@@ -98,7 +98,7 @@ module ExtractI18n
     end
 
     def original_content
-      @original_content ||= File.read(@file_path)
+      File.read(@file_path)
     end
   end
 end


### PR DESCRIPTION
Problem: 
- `original_content` was cached and mutated in-place, causing placeholder tokens to appear in diffs

Solution: 
- remove caching so `original_content` always reads directly from disk

Fixes #4 