### PR TITLE
Fix/link_to loop

### DIFF
--- a/lib/extract_i18n/slimkeyfy/slim_transformer.rb
+++ b/lib/extract_i18n/slimkeyfy/slim_transformer.rb
@@ -93,8 +93,9 @@ module ExtractI18n
             t_template: "#{before}#{html_tag}t('%s'%s)#{after}"
           )
           final_line = yield(change)
-          return parse_html_arguments(final_line, &block)
-        end
+          if final_line != @word.indentation + line
+            return parse_html_arguments(final_line, &block)
+          end
       end
       if final_line == line
         @word.indentation + final_line


### PR DESCRIPTION
Guard recursion to prevent infinite loop on unchanged lines.

In 'parse_html_arguments', only recurse when the transformed line actually
differs from the original. Previously we unconditionally called
'parse_html_arguments(final_line)' even if 'final_line' was identical,
causing endless prompts when the user declined to replace a match.

Now unchanged lines fall through to the “no more matches” logic and
return immediately, while “yes” answers still recurse once on the
new string.

Fixes #3 